### PR TITLE
Add API basics (Message API wrapper) & convert Hangman to Component system

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+#########
+# This script is intended for building the project on unix/linux platforms.
+# Please avoid adding OS-specific commands without taking other OSes into account.
+#
+# Troubleshooting:
+# - After codebase updates, it may be necessary to do a full rebuild.
+#   The easiest method of doing so is simply removing the output directory,
+#   then rebuilding using this script.
+# - Where possible, dependencies can be automatically installed using scripts/grab-deps.sh.
+#########
+
 # Get the script directory relative to the current directory
 script_dir=$(dirname "$0")
 
@@ -12,6 +23,7 @@ cd output
 
 # We need OpenSSL to run this.
 echo "Running cmake:"
+echo "$(cmake --version)"
 cmake .. -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl
 
 echo "Building the project:"
@@ -22,4 +34,6 @@ cp compile_commands.json ..
 
 echo "Fixing compile commands:"
 cd ..
-./scripts/fix-compile-commands.py include src auth
+# This is a helper script for ensuring all files are listed
+# in compile_commands.json (as headers are not always included)
+./scripts/fix-compile-commands.py src auth

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -1,0 +1,6 @@
+target_sources(GameBot
+    PRIVATE
+        api.cpp
+    PUBLIC
+        api.hpp
+)

--- a/src/api/api.cpp
+++ b/src/api/api.cpp
@@ -1,0 +1,1 @@
+#include "api.hpp"

--- a/src/api/api.hpp
+++ b/src/api/api.hpp
@@ -1,0 +1,4 @@
+#ifndef QB_API_HPP
+#define QB_API_HPP
+
+#endif // QB_API_HPP

--- a/src/api/message.hpp
+++ b/src/api/message.hpp
@@ -1,0 +1,52 @@
+#ifndef QB_MESSAGE_HPP
+#define QB_MESSAGE_HPP
+
+// In the future, we should probably avoid
+// having this include brought in. (TODO)
+#include <nlohmann/json.hpp>
+
+#include "utils/debug.hpp"
+#include "utils/json_utils.hpp"
+
+namespace qb::api
+{
+using json = nlohmann::json;
+class Message
+{
+    Message() = default;
+    Message(const std::string& id, const std::string& channel, const std::string& guild)
+        : id(id), channel(channel), guild(guild)
+    {
+    }
+
+public:
+    template <bool safe = false>
+    static Message create(const json& source)
+    {
+        // The json here should be the full data of the message.
+        // However, it's possible that a developer allows the wrong
+        // tier of JSON to propagate here. If we're running in safe
+        // mode, we check for that.
+        if constexpr (safe)
+        {
+            if (source.find("embed") == source.end())
+            {
+                ::qb::log::err("Message being constructed from incorrect tier ",
+                               "of JSON data (or invalid data):\n", source.dump(2));
+                return Message{};
+            }
+        }
+
+        return Message(source["id"], source["channel_id"],
+                       json_utils::def_str(source, "guild_id", ""));
+    }
+
+public:
+    // Make these public; there's no reason to have getters/setters.
+    std::string id;
+    std::string channel;
+    std::string guild;
+};
+} // namespace qb::api
+
+#endif // QB_MESSAGE_HPP

--- a/src/bot.cpp
+++ b/src/bot.cpp
@@ -2,6 +2,7 @@
 
 #include "components/messages.hpp"
 #include "components/sentiment.hpp"
+#include "components/games/hangman.hpp"
 #include "utils/debug.hpp"
 #include "utils/fileio.hpp"
 #include "utils/json_utils.hpp"
@@ -108,6 +109,7 @@ void qb::Bot::handle_event(const json& payload)
                 // Check if we have an action bound for this command
                 if (const auto& a = qb::parse::get_command_name(cmd); actions_.find(a) != actions_.end())
                 {
+                    qb::log::point("Found an action based command.");
                     const auto _unused_retval = actions_[a](cmd, api::Message::create(payload["d"]), *this);
                 }
             }
@@ -582,19 +584,8 @@ void qb::Bot::start()
     /**
      * Any delayed startup should go here.
      */
-
-    actions_.insert(std::make_pair("hangman", [](std::string cmd, api::Message msg, Bot& bot) {
-        bot.run_hangman(cmd, msg.channel);
-        return Result(Result::Value::Ok);
-    }));
-    actions_.insert(std::make_pair("guess", [](std::string cmd, api::Message msg, Bot& bot) {
-        bot.guess_hangman(cmd, msg.channel);
-        return Result(Result::Value::Ok);
-    }));
-    actions_.insert(std::make_pair("letter", [](std::string cmd, api::Message msg, Bot& bot) {
-        bot.letter_hangman(cmd, msg.channel);
-        return Result(Result::Value::Ok);
-    }));
+    qb::Hangman hangman;
+    hangman.register_actions(actions_);
 
     /**
      * Begin allowing completion handlers to fire.
@@ -632,76 +623,4 @@ void qb::Bot::shutdown()
     qb::log::point("Shutdown completed.");
 }
 
-// quick and dirty hangman impl
-bool qb::HangmanInstance::guess_letter(std::string l)
-{
-    if (l.size() != 1) return false;
-    if (qb::parse::in(l[0], word_)) return true;
-    guessed_letters_ += l;
-    return false;
-}
 
-bool qb::HangmanInstance::guess_word(std::string w)
-{
-    return w == word_;
-}
-
-std::string qb::HangmanInstance::str()
-{
-    // I said quick and dirty already, right?
-    // This is where things get dirty
-    std::string retval = word_;
-    std::transform(retval.begin(), retval.end(), retval.begin(),
-                   [&](char c) { return (qb::parse::in(c, guessed_letters_) ? c : '#'); });
-    // could this be more efficient? yes
-    // we'll call this a "todo"
-    return retval;
-}
-
-void qb::Bot::guess_hangman(const std::string& cmd, const std::string& channel)
-{
-    if (!hangman_inst_)
-    {
-        send("A hangman game is not currently in progress!", channel);
-        return;
-    }
-    const auto guess = qb::parse::trim(std::string(std::find(cmd.begin(), cmd.end(), ' '), cmd.end()));
-    if (hangman_inst_->guess_word(guess))
-    {
-        send("You are correct! The word is " + hangman_inst_->word_ + "! Game ending...", channel);
-        hangman_inst_.reset();
-        return;
-    }
-    send("That is not the correct word! Ouch!", channel);
-}
-
-void qb::Bot::run_hangman(const std::string& cmd, const std::string& channel)
-{
-    if (hangman_inst_)
-    {
-        send("A hangman game is already in progress!", channel);
-        return;
-    }
-    // choose a random word
-    const auto words = qb::fileio::get_all();
-    // this was actually way easier than expected
-    // already had all the framework in place to do this
-    auto word = *qb::select_randomly(words.begin(), words.end());
-    std::transform(word.begin(), word.end(), word.begin(), tolower);
-    hangman_inst_.emplace(word);
-    send("[Hangman] `" + hangman_inst_->str() + "`", channel);
-}
-
-void qb::Bot::letter_hangman(const std::string& cmd, const std::string& channel)
-{
-    if (!hangman_inst_)
-    {
-        send("A hangman game is not currently in progress!", channel);
-        return;
-    }
-    const auto guess = qb::parse::trim(std::string(std::find(cmd.begin(), cmd.end(), ' '), cmd.end()));
-    auto letters     = qb::parse::concatenate(qb::parse::split(guess), "");
-    std::transform(letters.begin(), letters.end(), letters.begin(), tolower);
-    hangman_inst_->guessed_letters_ += letters;
-    send("[Hangman] `" + hangman_inst_->str() + "`", channel);
-}

--- a/src/bot.cpp
+++ b/src/bot.cpp
@@ -108,7 +108,7 @@ void qb::Bot::handle_event(const json& payload)
                 // Check if we have an action bound for this command
                 if (const auto& a = qb::parse::get_command_name(cmd); actions_.find(a) != actions_.end())
                 {
-                    const auto _unused_retval = actions_[a](cmd, channel, *this);
+                    const auto _unused_retval = actions_[a](cmd, api::Message::create(payload["d"]), *this);
                 }
             }
         }
@@ -560,7 +560,7 @@ void qb::Bot::start()
     web::context web_context;
     web_context.initialize();
     web_ctx_ = &web_context;
-    dead = false;
+    dead     = false;
 
     qb::log::point("Creating timer for ping operations.");
     timer_.emplace(*web_context.ioc_ptr(), boost::asio::chrono::milliseconds(hb_interval_ms_));
@@ -583,11 +583,20 @@ void qb::Bot::start()
      * Any delayed startup should go here.
      */
 
-    actions_.insert(std::make_pair("hangman", [](std::string cmd, std::string channel, Bot& bot) { bot.run_hangman(cmd, channel); return Result(Result::Value::Ok); }) );
-    actions_.insert(std::make_pair("guess", [](std::string cmd, std::string channel, Bot& bot) { bot.guess_hangman(cmd, channel); return Result(Result::Value::Ok); }));
-    actions_.insert(std::make_pair("letter", [](std::string cmd, std::string channel, Bot& bot) { bot.letter_hangman(cmd, channel); return Result(Result::Value::Ok); }));
+    actions_.insert(std::make_pair("hangman", [](std::string cmd, api::Message msg, Bot& bot) {
+        bot.run_hangman(cmd, msg.channel);
+        return Result(Result::Value::Ok);
+    }));
+    actions_.insert(std::make_pair("guess", [](std::string cmd, api::Message msg, Bot& bot) {
+        bot.guess_hangman(cmd, msg.channel);
+        return Result(Result::Value::Ok);
+    }));
+    actions_.insert(std::make_pair("letter", [](std::string cmd, api::Message msg, Bot& bot) {
+        bot.letter_hangman(cmd, msg.channel);
+        return Result(Result::Value::Ok);
+    }));
 
-    /** 
+    /**
      * Begin allowing completion handlers to fire.
      * Blocking call - anything after this is only executed after
      * the application stops (i.e. the bot shuts down)

--- a/src/bot.hpp
+++ b/src/bot.hpp
@@ -11,25 +11,6 @@
 
 namespace qb
 {
-struct HangmanInstance
-{
-    // this is very much quick-and-dirty
-    // quick implementation for fun
-    HangmanInstance(std::string word) : word_(word)
-    {
-        guessed_letters_ += ' ';
-    }
-
-    bool guess_letter(std::string l);
-    bool guess_word(std::string w);
-
-    std::string str();
-
-    std::string guessed_letters_;
-    std::string word_;
-
-    size_t max_guesses_{5};
-};
 
 class Bot
 {
@@ -67,6 +48,7 @@ private:
     void handle_hello(const nlohmann::json& payload);
     void handle_event(const nlohmann::json& payload);
 
+public: /** Send is a part of our public API currently. */
     // Sends a message in a Discord channel.
     void send(std::string msg, std::string channel);
 
@@ -80,10 +62,6 @@ private:
 
     void configure(const std::string& cmd, const nlohmann::json& data);
     void assign_emote(const std::string& cmd, const std::string& channel);
-
-    void guess_hangman(const std::string& cmd, const std::string& channel);
-    void run_hangman(const std::string& cmd, const std::string& channel);
-    void letter_hangman(const std::string& cmd, const std::string& channel);
 
 private:
     void handle_queue_timeout(const std::string& message_id, const boost::system::error_code& error);
@@ -111,8 +89,6 @@ private:
     bool log_loud_{false};       // Debug - For lack of a better setup, this prints more.
 
     std::unordered_map<std::string, qb::queue> queues_; // Our actual queues.
-
-    std::optional<HangmanInstance> hangman_inst_;
 
     // Hashmap of callbacks; these are our commands.
     ::qb::Actions actions_;

--- a/src/components/CMakeLists.txt
+++ b/src/components/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(games)
+
 target_sources(GameBot
     PRIVATE
         messages.cpp

--- a/src/components/action.hpp
+++ b/src/components/action.hpp
@@ -19,6 +19,7 @@ public:
     enum class Value {
         Ok,
     };
+    static Result ok() { return Result(Value::Ok); }
 
     Result(std::string err) : err_(std::move(err)) {}
     Result(::qb::Result::Value result) : val(result) {}
@@ -28,7 +29,9 @@ private:
     std::string err_;
 };
 
-using Actions = std::unordered_map<std::string, std::function<::qb::Result(std::string, api::Message, qb::Bot&)>>;
+using ActionCallback = std::function<::qb::Result(const std::string&, const api::Message&, qb::Bot&)>;
+
+using Actions = std::unordered_map<std::string, ActionCallback>;
 }
 
 #endif // QB_ACTION_HPP

--- a/src/components/action.hpp
+++ b/src/components/action.hpp
@@ -6,6 +6,10 @@
 #include <functional>
 #include <unordered_map>
 
+// TODO This is now pulling in JSON
+// This is not exactly ideal
+#include "api/message.hpp"
+
 namespace qb
 {
 class Bot;
@@ -24,7 +28,7 @@ private:
     std::string err_;
 };
 
-using Actions = std::unordered_map<std::string, std::function<::qb::Result(/*std::vector<*/std::string/*>*/, std::string, qb::Bot&)>>;
+using Actions = std::unordered_map<std::string, std::function<::qb::Result(std::string, api::Message, qb::Bot&)>>;
 }
 
 #endif // QB_ACTION_HPP

--- a/src/components/component.hpp
+++ b/src/components/component.hpp
@@ -1,16 +1,36 @@
 #ifndef QB_COMPONENT_HPP
 #define QB_COMPONENT_HPP
 
+#include <utility>
+
 #include "action.hpp"
 
-namespace qb{ 
-class Component {
-    public:
-        virtual void register_actions(Actions& actions) = 0;
+namespace qb
+{
+class Component
+{
+public:
+    virtual void register_actions(Actions& actions) = 0;
 
+protected:
+    // Component provides a number of helper functions for children.
+
+    /**
+     * Register a group of actions that all follow the same format.
+     */
+    template <typename T, typename... Ts>
+    void register_all(T& actions, typename T::value_type val, Ts... vals) const
+    {
+        actions.emplace(std::move(val));
+        register_all(actions, std::forward<Ts>(vals)...);
+    }
+    template <typename T>
+    void register_all(T& actions, typename T::value_type val) const
+    {
+        actions.emplace(std::move(val));
+    }
 };
 
-
-}
+} // namespace qb
 
 #endif // QB_COMPONENT_HPP

--- a/src/components/games/CMakeLists.txt
+++ b/src/components/games/CMakeLists.txt
@@ -1,0 +1,6 @@
+target_sources(GameBot
+    PRIVATE
+        hangman.cpp
+    PUBLIC
+        hangman.hpp
+)

--- a/src/components/games/hangman.cpp
+++ b/src/components/games/hangman.cpp
@@ -1,0 +1,96 @@
+#include "hangman.hpp"
+
+#include "bot.hpp"
+#include "utils/parse.hpp"
+#include "utils/fileio.hpp"
+#include "utils/utils.hpp"
+
+#include <functional>
+#include <algorithm>
+
+void qb::Hangman::register_actions(Actions& actions)
+{
+    using namespace std::placeholders;
+    register_all(actions, std::make_pair("hangman", (ActionCallback)std::bind(&qb::Hangman::run_hangman, this, _1, _2, _3)),
+                 std::make_pair("guess", (ActionCallback)std::bind(&qb::Hangman::guess_hangman, this, _1, _2, _3)),
+                 std::make_pair("letter", (ActionCallback)std::bind(&qb::Hangman::letter_hangman, this, _1, _2, _3)));
+}
+
+qb::Result qb::Hangman::guess_hangman(const std::string& cmd, const api::Message& msg, Bot& bot)
+{
+    const auto& channel = msg.channel;
+    if (guessed_letters_.empty())
+    {
+        bot.send("A hangman game is not currently in progress!", channel);
+        return qb::Result::ok();
+    }
+    const auto guess = qb::parse::trim(std::string(std::find(cmd.begin(), cmd.end(), ' '), cmd.end()));
+    if (guess_word(guess))
+    {
+        bot.send("You are correct! The word is " + word_ + "! Game ending...", channel);
+        reset();
+        return qb::Result::ok();
+    }
+    bot.send("That is not the correct word! Ouch!", channel);
+    return qb::Result::ok();
+}
+
+qb::Result qb::Hangman::run_hangman(const std::string& cmd, const api::Message& msg, Bot& bot)
+{
+    const auto& channel = msg.channel;
+    if (!guessed_letters_.empty())
+    {
+        bot.send("A hangman game is already in progress!", channel);
+        return qb::Result::ok();
+    }
+    // choose a random word
+    const auto words = qb::fileio::get_all();
+    // this was actually way easier than expected
+    // already had all the framework in place to do this
+    word_ = *qb::select_randomly(words.begin(), words.end());
+    std::transform(word_.begin(), word_.end(), word_.begin(), tolower);
+    bot.send("[Hangman] `" + str() + "`", channel);
+        return qb::Result::ok();
+}
+
+qb::Result qb::Hangman::letter_hangman(const std::string& cmd, const api::Message& msg, Bot& bot)
+{
+    const auto& channel = msg.channel;
+    if (guessed_letters_.empty())
+    {
+        bot.send("A hangman game is not currently in progress!", channel);
+        return qb::Result::ok();
+    }
+    const auto guess = qb::parse::trim(std::string(std::find(cmd.begin(), cmd.end(), ' '), cmd.end()));
+    auto letters     = qb::parse::concatenate(qb::parse::split(guess), "");
+    std::transform(letters.begin(), letters.end(), letters.begin(), tolower);
+    guessed_letters_ += letters;
+    bot.send("[Hangman] `" + str() + "`", channel);
+        return qb::Result::ok();
+}
+
+// quick and dirty hangman impl
+bool qb::Hangman::guess_letter(std::string l)
+{
+    if (l.size() != 1) return false;
+    if (qb::parse::in(l[0], word_)) return true;
+    guessed_letters_ += l;
+    return false;
+}
+
+bool qb::Hangman::guess_word(std::string w)
+{
+    return w == word_;
+}
+
+std::string qb::Hangman::str()
+{
+    // I said quick and dirty already, right?
+    // This is where things get dirty
+    std::string retval = word_;
+    std::transform(retval.begin(), retval.end(), retval.begin(),
+                   [&](char c) { return (qb::parse::in(c, guessed_letters_) ? c : '#'); });
+    // could this be more efficient? yes
+    // we'll call this a "todo"
+    return retval;
+}

--- a/src/components/games/hangman.cpp
+++ b/src/components/games/hangman.cpp
@@ -1,19 +1,21 @@
 #include "hangman.hpp"
 
 #include "bot.hpp"
-#include "utils/parse.hpp"
 #include "utils/fileio.hpp"
+#include "utils/parse.hpp"
 #include "utils/utils.hpp"
 
-#include <functional>
 #include <algorithm>
+#include <functional>
 
 void qb::Hangman::register_actions(Actions& actions)
 {
     using namespace std::placeholders;
-    register_all(actions, std::make_pair("hangman", (ActionCallback)std::bind(&qb::Hangman::run_hangman, this, _1, _2, _3)),
-                 std::make_pair("guess", (ActionCallback)std::bind(&qb::Hangman::guess_hangman, this, _1, _2, _3)),
-                 std::make_pair("letter", (ActionCallback)std::bind(&qb::Hangman::letter_hangman, this, _1, _2, _3)));
+    register_all(
+        actions,
+        std::make_pair("hangman", (ActionCallback)std::bind(&qb::Hangman::run_hangman, this, _1, _2, _3)),
+        std::make_pair("guess", (ActionCallback)std::bind(&qb::Hangman::guess_hangman, this, _1, _2, _3)),
+        std::make_pair("letter", (ActionCallback)std::bind(&qb::Hangman::letter_hangman, this, _1, _2, _3)));
 }
 
 qb::Result qb::Hangman::guess_hangman(const std::string& cmd, const api::Message& msg, Bot& bot)
@@ -37,6 +39,7 @@ qb::Result qb::Hangman::guess_hangman(const std::string& cmd, const api::Message
 
 qb::Result qb::Hangman::run_hangman(const std::string& cmd, const api::Message& msg, Bot& bot)
 {
+    qb::log::point("Starting a hangman game.");
     const auto& channel = msg.channel;
     if (!guessed_letters_.empty())
     {
@@ -49,8 +52,10 @@ qb::Result qb::Hangman::run_hangman(const std::string& cmd, const api::Message& 
     // already had all the framework in place to do this
     word_ = *qb::select_randomly(words.begin(), words.end());
     std::transform(word_.begin(), word_.end(), word_.begin(), tolower);
+    guessed_letters_ = " ";
     bot.send("[Hangman] `" + str() + "`", channel);
-        return qb::Result::ok();
+    qb::log::point("Finished initializing a hangman game.");
+    return qb::Result::ok();
 }
 
 qb::Result qb::Hangman::letter_hangman(const std::string& cmd, const api::Message& msg, Bot& bot)
@@ -66,7 +71,7 @@ qb::Result qb::Hangman::letter_hangman(const std::string& cmd, const api::Messag
     std::transform(letters.begin(), letters.end(), letters.begin(), tolower);
     guessed_letters_ += letters;
     bot.send("[Hangman] `" + str() + "`", channel);
-        return qb::Result::ok();
+    return qb::Result::ok();
 }
 
 // quick and dirty hangman impl

--- a/src/components/games/hangman.hpp
+++ b/src/components/games/hangman.hpp
@@ -1,0 +1,47 @@
+#ifndef QB_HANGMAN_HPP
+#define QB_HANGMAN_HPP
+
+#include "../component.hpp"
+
+#include <string>
+
+namespace qb
+{
+class Hangman : public Component
+{
+    constexpr static size_t MAX_GUESSES = 5;
+
+public:
+    // this is very much quick-and-dirty
+    // quick implementation for fun
+
+    qb::Result run_hangman(const std::string& cmd, const api::Message& msg, Bot& bot);
+    qb::Result guess_hangman(const std::string& cmd, const api::Message& msg, Bot& bot);
+    qb::Result letter_hangman(const std::string& cmd, const api::Message& msg, Bot& bot);
+
+    void register_actions(Actions& actions) override;
+
+private:
+    void reset()
+    {
+        guessed_letters_.clear();
+        word_.clear();
+        max_guesses_ = MAX_GUESSES;
+    }
+
+    bool guess_letter(std::string l);
+    bool guess_word(std::string w);
+
+    std::string str();
+
+    // This always contains a space during runtime,
+    // so we can use it being empty to indicate that
+    // we are not running a hangman session.
+    std::string guessed_letters_;
+    std::string word_;
+
+    size_t max_guesses_{MAX_GUESSES};
+};
+} // namespace qb
+
+#endif // QB_HANGMAN_HPP

--- a/src/utils/json_utils.hpp
+++ b/src/utils/json_utils.hpp
@@ -27,6 +27,8 @@ D def(const json& jd, const std::string& key, const D& d)
     return d;
 }
 
+constexpr auto def_str = def<std::string>;
+
 template <typename T>
 std::optional<T> get_opt(const json& jd, const std::string& key)
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,12 +12,12 @@ add_subdirectory(${GOOGLETEST_DIR}
                  ${PROJECT_BINARY_DIR}/gtest
                  EXCLUDE_FROM_ALL)
 
-add_executable(QueueBotTests Test_Parse.cpp Test_FileIO.cpp Test_Utils.cpp
-    ${CMAKE_SOURCE_DIR}/src/parse.cpp
-    ${CMAKE_SOURCE_DIR}/src/fileio.cpp
-    ${CMAKE_SOURCE_DIR}/src/utils.cpp
+add_executable(QueueBotTests Test_Parse.cpp Test_FileIO.cpp Test_Utils.cpp Test_Component.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/parse.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/fileio.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/utils.cpp
 )
-target_include_directories(QueueBotTests PRIVATE "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>")
+target_include_directories(QueueBotTests PRIVATE "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>")
 target_include_directories(QueueBotTests PRIVATE "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/deps/nlohmann_json/single_include>")
 
 if (HAS_FS)

--- a/test/Test_Component.cpp
+++ b/test/Test_Component.cpp
@@ -1,0 +1,59 @@
+#include "gtest/gtest.h"
+
+#include "components/component.hpp"
+#include "components/action.hpp"
+
+#include <functional>
+#include <string>
+#include <utility>
+
+using namespace qb;
+
+class TestComponent : public Component
+{
+public:
+    qb::Result action_one(const std::string& cmd, const api::Message& msg, Bot& bot) {
+        return qb::Result::ok();
+    }
+    qb::Result action_two(const std::string& cmd, const api::Message& msg, Bot& bot){
+        return qb::Result::ok();}
+
+    void register_actions(Actions& actions) override
+    {
+        using namespace std::placeholders;
+        register_all(
+            actions,
+            std::make_pair("one", (ActionCallback)std::bind(&TestComponent::action_one, this, _1, _2, _3)),
+            std::make_pair("two", (ActionCallback)std::bind(&TestComponent::action_two, this, _1, _2, _3)));
+    }
+};
+
+TEST(Component, Register)
+{
+    TestComponent test;
+
+    ::qb::Actions actions;
+
+    test.register_actions(actions);
+
+    ASSERT_EQ(actions.size(), 2);
+}
+
+TEST(Component, Callback)
+{
+    TestComponent test;
+
+    ::qb::Actions actions;
+
+    test.register_actions(actions);
+
+    const auto itr1 = actions.find("one");
+    ASSERT_NE(itr1, actions.end());
+    const auto itr2 = actions.find("two");
+    ASSERT_NE(itr2, actions.end());
+    const auto itr3 = actions.find("three");
+    ASSERT_EQ(itr3, actions.end());
+
+    int _cursed = 0;
+    const auto _unused = actions["one"]("", api::Message::create<true>(nlohmann::json{}), *(Bot*)(&_cursed));
+}

--- a/test/Test_FileIO.cpp
+++ b/test/Test_FileIO.cpp
@@ -1,8 +1,8 @@
-#include "fileio.hpp"
+#include "utils/fileio.hpp"
 
-#include "config.hpp"
-#include "parse.hpp"
-#include "utils.hpp"
+#include "components/config.hpp"
+#include "utils/parse.hpp"
+#include "utils/utils.hpp"
 #include "gtest/gtest.h"
 #include <string>
 #include <vector>
@@ -31,9 +31,11 @@ TEST(FileIO, GetSets)
     // Test exactly what we have in src/bot.cpp for redundancy
     auto components = qb::parse::split(" recall:wordset1", ':');
     components.erase(components.begin());
-    EXPECT_EQ(qb::parse::concatenate(qb::fileio::get_set(components.at(0)), ","), "set,is a,set of,worders");
+    EXPECT_EQ(qb::parse::concatenate(qb::fileio::get_set(components.at(0)), ","),
+              "set,is a,set of,worders");
 
     components = qb::parse::split(" recall:wordset1:default", ':');
     components.erase(components.begin());
-    EXPECT_EQ(qb::parse::concatenate(qb::fileio::get_sets(components), ","), "set,is a,set of,worders,this,is a,set of,words");
+    EXPECT_EQ(qb::parse::concatenate(qb::fileio::get_sets(components), ","),
+              "set,is a,set of,worders,this,is a,set of,words");
 }

--- a/test/Test_Parse.cpp
+++ b/test/Test_Parse.cpp
@@ -1,4 +1,4 @@
-#include "parse.hpp"
+#include "utils/parse.hpp"
 
 #include "gtest/gtest.h"
 #include <string>

--- a/test/Test_Utils.cpp
+++ b/test/Test_Utils.cpp
@@ -1,4 +1,4 @@
-#include "utils.hpp"
+#include "utils/utils.hpp"
 #include "gtest/gtest.h"
 
 using namespace qb;


### PR DESCRIPTION
Note: There are definitely ways that the component / action registration could be improved. This should work for now, though. @novelqq 
If extra information is needed from the `MESSAGE_CREATE` event, this should be added to `api::Message::create` (that is, add the information to the Message API object wrapper)
Extra callback functionality shouldn't be needed from here, except to make things less hacky really.