### PR TITLE
Add basic parsing support / flexibility to queue command

### DIFF
--- a/src/components/games/gamequeue.cpp
+++ b/src/components/games/gamequeue.cpp
@@ -7,115 +7,134 @@
 
 std::string qb::Queue::to_str() const
 {
-    return "Queueing a game of " + game_ + " called " + name_ + " with **" + std::to_string(users.size()) + "** players. (Max **" + std::to_string(max_size_) + "**)";
+    return "Queueing a game of " + game_ + " called " + name_ + " with **" +
+           std::to_string(users.size()) + "** players. (Max **" + std::to_string(max_size_) + "**)";
 }
 
 void qb::QueueComponent::register_actions(Actions<>& actions)
 {
     using namespace std::placeholders;
-    register_all(
-        actions,
-        std::make_pair("queue", (ActionCallback)std::bind(&qb::QueueComponent::add_queue, this, _1, _2, _3))
-    );
+    register_all(actions, std::make_pair("queue", (ActionCallback)std::bind(&qb::QueueComponent::add_queue,
+                                                                            this, _1, _2, _3)));
 }
 
 qb::Result qb::QueueComponent::add_queue(const std::string& cmd, const api::Message& msg, Bot& bot)
 {
-    const auto& channel = msg.channel;
-    std::vector<std::string> tokens = qb::parse::split(cmd);
-    if( tokens.size() != 5)
-    {
-        bot.send("Incorrect number of parameters given. Proper format : !qb queue <game> <queue_name> <max_size> <time>", channel);
-        return qb::Result::ok();
-    }
+    const auto& channel                      = msg.channel;
+    auto [args, numeric_args, duration_args] = qb::parse::decompose_command(cmd);
+
+    Queue new_queue = [&]() {
+        std::optional<std::string> name;
+        std::optional<std::string> game;
+        if (args.size() == 1)
+        {
+            game = args[0];
+        }
+        else if (args.size() > 1)
+        {
+            game = args[0];
+            name = args[1];
+        }
+    }();
+
     else
     {
-        const auto game = tokens[1];
-        const auto name = tokens[2];
+        const auto game     = tokens[1];
+        const auto name     = tokens[2];
         const auto max_size = std::stoi(tokens[3]);
-        const auto time = std::stoi(tokens[4]);
-        Queue new_queue = Queue(name, game, max_size, time);
-        auto endpoint = msg.endpoint();
+        const auto time     = std::stoi(tokens[4]);
+        Queue new_queue     = Queue(name, game, max_size, time);
+        auto endpoint       = msg.endpoint();
         bot.get_context()->del(endpoint);
-        send_yn_message(new_queue, bot, "Queueing a game of " + game + " called " + name + " with **0** players. (Max players: " + tokens[3] + ". Time remaining: " + tokens[4] + ")", channel);
+        send_yn_message(new_queue, bot,
+                        "Queueing a game of " + game + " called " + name +
+                            " with **0** players. (Max players: " + tokens[3] +
+                            ". Time remaining: " + tokens[4] + ")",
+                        channel);
         return qb::Result::ok();
-
     }
 }
 
-nlohmann::json qb::QueueComponent::send_yn_message(Queue& queue, Bot& bot, const std::string& message, const std::string& channel)
+nlohmann::json qb::QueueComponent::send_yn_message(Queue& queue,
+                                                   Bot& bot,
+                                                   const std::string& message,
+                                                   const std::string& channel)
 {
     qb::log::point("A queue message.");
     const auto resp = send_removable_message(bot, message, channel);
-    if(resp.empty()) return {};
+    if (resp.empty()) return {};
     active_queues.emplace(resp["id"], queue);
     bot.on_message_id(resp["id"], bind_message_action(&qb::QueueComponent::add_yn_reaction, this));
     return resp;
-
 }
-qb::Result qb::QueueComponent::add_yn_reaction( const std::string& message_id, const api::Message& message, Bot& bot)
+qb::Result qb::QueueComponent::add_yn_reaction(const std::string& message_id, const api::Message& message, Bot& bot)
 {
     if (const auto& yes_emote = qb::parse::emote_snowflake(qb::fileio::get_emote("yes")); yes_emote)
     {
         bot.get_context()->put(qb::endpoints::reaction(message.channel, message_id, *yes_emote), {});
     }
-    
+
     bot.on_message_reaction(message, [this, em = qb::fileio::get_emote("yes"), message_id, message](
-                                             const std::string&, const api::Reaction& reaction, Bot& bot, int count) {
-            
-            qb::log::point("> Checking if reaction: ", reaction.to_string(),
-                           " is the correct reaction to edit the message: ", message_id);
-            const auto& bID = bot.idref(); // ALSO A HACK
-            if (!bot.idref())
+                                         const std::string&, const api::Reaction& reaction, Bot& bot, int count) {
+        qb::log::point("> Checking if reaction: ", reaction.to_string(),
+                       " is the correct reaction to edit the message: ", message_id);
+        const auto& bID = bot.idref(); // ALSO A HACK
+        if (!bot.idref())
+        {
+            qb::log::point("> > Did not edit message, as the bot has no ID.");
+            bot.idref() = reaction.user.id;
+            return qb::Result::Value::PersistCallback;
+        }
+        if (reaction.user.id == *bot.idref())
+        {
+            qb::log::point("> > Did not edit message, as it was sent by the bot.");
+            return qb::Result::Value::PersistCallback;
+        }
+        if (qb::parse::compare_emotes(em, reaction.emoji))
+        {
+            if (count == 0)
             {
-                qb::log::point("> > Did not edit message, as the bot has no ID.");
-                bot.idref() = reaction.user.id;
-                return qb::Result::Value::PersistCallback;
-            }
-            if (reaction.user.id == *bot.idref())
-            {
-                qb::log::point("> > Did not edit message, as it was sent by the bot.");
-                return qb::Result::Value::PersistCallback;
-            }
-            if (qb::parse::compare_emotes(em, reaction.emoji))
-            {
-                if(count == 0){
-                    auto& users = active_queues.at(message_id).users;
-                    const auto itr = std::remove(users.begin(), users.end(), reaction.user.id);
-                    if (itr == users.end()) {
+                auto& users    = active_queues.at(message_id).users;
+                const auto itr = std::remove(users.begin(), users.end(), reaction.user.id);
+                if (itr == users.end())
+                {
                     qb::log::point("The user ", reaction.user.id, " was not registered!");
                     return qb::Result::Value::PersistCallback;
-                    }
-                    users.erase(itr, users.end());
                 }
-                else{
-                    active_queues.at(message.id).users.push_back(reaction.user.id);
-                    qb::log::point("Editing message");
-                    
-                    if(active_queues.empty())
-                    {
-                        qb::log::point("Oh no, active queues is empty");
-                    }
-                    if(active_queues.at(message.id).users.size() == active_queues.at(message_id).max_size_)
-                    {
-                        auto& users = active_queues.at(message_id).users;
-                        std::stringstream ss;
-                        for (const auto& i: users){
-                            ss << "<@" << i << "> ";
-                        }
-                        ss << "\nQueue finished! Please get ready to play " << active_queues.at(message.id).game_ << " with " <<  active_queues.at(message.id).name_ << ".";
-                        send_removable_message(bot, ss.str(), message.channel);
-                        bot.get_context()->del(message.endpoint());
-                        active_queues.erase(message_id);
-                        return qb::Result::Value::Ok;
-                    }
-                }
-                nlohmann::json new_message;
-                new_message["content"] = active_queues.at(message.id).to_str();
-                bot.get_context()->patch(message.endpoint(), new_message.dump());
-                return qb::Result::Value::PersistCallback;
+                users.erase(itr, users.end());
             }
+            else
+            {
+                active_queues.at(message.id).users.push_back(reaction.user.id);
+                qb::log::point("Editing message");
+
+                if (active_queues.empty())
+                {
+                    qb::log::point("Oh no, active queues is empty");
+                }
+                if (active_queues.at(message.id).users.size() == active_queues.at(message_id).max_size_)
+                {
+                    auto& users = active_queues.at(message_id).users;
+                    std::stringstream ss;
+                    for (const auto& i : users)
+                    {
+                        ss << "<@" << i << "> ";
+                    }
+                    ss << "\nQueue finished! Please get ready to play "
+                       << active_queues.at(message.id).game_ << " with "
+                       << active_queues.at(message.id).name_ << ".";
+                    send_removable_message(bot, ss.str(), message.channel);
+                    bot.get_context()->del(message.endpoint());
+                    active_queues.erase(message_id);
+                    return qb::Result::Value::Ok;
+                }
+            }
+            nlohmann::json new_message;
+            new_message["content"] = active_queues.at(message.id).to_str();
+            bot.get_context()->patch(message.endpoint(), new_message.dump());
             return qb::Result::Value::PersistCallback;
-        });
+        }
+        return qb::Result::Value::PersistCallback;
+    });
     return qb::Result::ok();
 }

--- a/src/components/games/gamequeue.cpp
+++ b/src/components/games/gamequeue.cpp
@@ -7,8 +7,9 @@
 
 std::string qb::Queue::to_str() const
 {
-    return "Queueing a game of " + game_ + " called " + name_ + " with **" +
-           std::to_string(users.size()) + "** players. (Max **" + std::to_string(max_size_) + "**)";
+    std::string max_players = max_size_ ? (" (Max **" + std::to_string(*max_size_) + "**)") : "";
+    return "Queueing a game of " + get_game() + " called " + get_name() + " with **" +
+           std::to_string(users.size()) + "** players." + max_players;
 }
 
 void qb::QueueComponent::register_actions(Actions<>& actions)
@@ -20,10 +21,13 @@ void qb::QueueComponent::register_actions(Actions<>& actions)
 
 qb::Result qb::QueueComponent::add_queue(const std::string& cmd, const api::Message& msg, Bot& bot)
 {
-    const auto& channel                      = msg.channel;
-    auto [args, numeric_args, duration_args] = qb::parse::decompose_command(cmd);
+    const auto& channel = msg.channel;
 
     Queue new_queue = [&]() {
+        auto [args, numeric_args, duration_args] = qb::parse::decompose_command(cmd);
+        qb::log::point("Queue creation: \n\tFound ", args.size(), " arguments\n\tFound ",
+                       numeric_args.size(), " numeric args\n\tFound ", duration_args.size(),
+                       " duration args");
         std::optional<std::string> name;
         std::optional<std::string> game;
         if (args.size() == 1)
@@ -35,24 +39,23 @@ qb::Result qb::QueueComponent::add_queue(const std::string& cmd, const api::Mess
             game = args[0];
             name = args[1];
         }
+        std::optional<int> max_size;
+        if (numeric_args.size() != 0)
+        {
+            max_size = numeric_args[0];
+        }
+        std::optional<std::chrono::duration<long>> time;
+        if (duration_args.size() != 0)
+        {
+            time = duration_args[0];
+        }
+        return Queue(name, game, max_size, time);
     }();
 
-    else
-    {
-        const auto game     = tokens[1];
-        const auto name     = tokens[2];
-        const auto max_size = std::stoi(tokens[3]);
-        const auto time     = std::stoi(tokens[4]);
-        Queue new_queue     = Queue(name, game, max_size, time);
-        auto endpoint       = msg.endpoint();
-        bot.get_context()->del(endpoint);
-        send_yn_message(new_queue, bot,
-                        "Queueing a game of " + game + " called " + name +
-                            " with **0** players. (Max players: " + tokens[3] +
-                            ". Time remaining: " + tokens[4] + ")",
-                        channel);
-        return qb::Result::ok();
-    }
+    auto endpoint = msg.endpoint();
+    bot.get_context()->del(endpoint);
+    send_yn_message(new_queue, bot, new_queue.to_str(), channel);
+    return qb::Result::ok();
 }
 
 nlohmann::json qb::QueueComponent::send_yn_message(Queue& queue,
@@ -112,17 +115,17 @@ qb::Result qb::QueueComponent::add_yn_reaction(const std::string& message_id, co
                 {
                     qb::log::point("Oh no, active queues is empty");
                 }
-                if (active_queues.at(message.id).users.size() == active_queues.at(message_id).max_size_)
+                auto& q     = active_queues.at(message_id);
+                auto& users = active_queues.at(message_id).users;
+                if (q.max_size_ && users.size() == *(q.max_size_))
                 {
-                    auto& users = active_queues.at(message_id).users;
                     std::stringstream ss;
                     for (const auto& i : users)
                     {
                         ss << "<@" << i << "> ";
                     }
-                    ss << "\nQueue finished! Please get ready to play "
-                       << active_queues.at(message.id).game_ << " with "
-                       << active_queues.at(message.id).name_ << ".";
+                    ss << "\nQueue finished! Please get ready to play " << (q.game_ ? *q.game_ : "a game")
+                       << " with " << (q.name_ ? *q.name_ : "friends!") << "!";
                     send_removable_message(bot, ss.str(), message.channel);
                     bot.get_context()->del(message.endpoint());
                     active_queues.erase(message_id);

--- a/src/components/games/gamequeue.cpp
+++ b/src/components/games/gamequeue.cpp
@@ -9,7 +9,8 @@ std::string qb::Queue::to_str() const
 {
     std::string max_players = max_size_ ? (" (Max **" + std::to_string(*max_size_) + "**)") : "";
     return "Queueing a game of " + get_game() + " called " + get_name() + " with **" +
-           std::to_string(users.size()) + "** players." + max_players;
+           std::to_string(users.size()) + "** players." + max_players + " React with " +
+           qb::fileio::get_emote("yes") + " to join the queue!";
 }
 
 void qb::QueueComponent::register_actions(Actions<>& actions)
@@ -70,6 +71,7 @@ nlohmann::json qb::QueueComponent::send_yn_message(Queue& queue,
     bot.on_message_id(resp["id"], bind_message_action(&qb::QueueComponent::add_yn_reaction, this));
     return resp;
 }
+
 qb::Result qb::QueueComponent::add_yn_reaction(const std::string& message_id, const api::Message& message, Bot& bot)
 {
     if (const auto& yes_emote = qb::parse::emote_snowflake(qb::fileio::get_emote("yes")); yes_emote)
@@ -92,6 +94,11 @@ qb::Result qb::QueueComponent::add_yn_reaction(const std::string& message_id, co
         {
             qb::log::point("> > Did not edit message, as it was sent by the bot.");
             return qb::Result::Value::PersistCallback;
+        }
+        if (qb::parse::compare_emotes(qb::fileio::get_emote("remove_message"), reaction.emoji))
+        {
+            qb::log::point("QueueComponent using Delete emoji to end queue.");
+            return *end_queue(message_id, reaction, bot).val;
         }
         if (qb::parse::compare_emotes(em, reaction.emoji))
         {
@@ -119,17 +126,7 @@ qb::Result qb::QueueComponent::add_yn_reaction(const std::string& message_id, co
                 auto& users = active_queues.at(message_id).users;
                 if (q.max_size_ && users.size() == *(q.max_size_))
                 {
-                    std::stringstream ss;
-                    for (const auto& i : users)
-                    {
-                        ss << "<@" << i << "> ";
-                    }
-                    ss << "\nQueue finished! Please get ready to play " << (q.game_ ? *q.game_ : "a game")
-                       << " with " << (q.name_ ? *q.name_ : "friends!") << "!";
-                    send_removable_message(bot, ss.str(), message.channel);
-                    bot.get_context()->del(message.endpoint());
-                    active_queues.erase(message_id);
-                    return qb::Result::Value::Ok;
+                    return *end_queue(message_id, reaction, bot).val;
                 }
             }
             nlohmann::json new_message;
@@ -140,4 +137,26 @@ qb::Result qb::QueueComponent::add_yn_reaction(const std::string& message_id, co
         return qb::Result::Value::PersistCallback;
     });
     return qb::Result::ok();
+}
+
+qb::Result qb::QueueComponent::end_queue(const std::string& message_id, const api::Reaction reaction, Bot& bot)
+{
+    if (active_queues.find(message_id) == active_queues.end())
+    {
+        qb::log::warn("Already deleted queue at message ID ", message_id);
+        return qb::Result::Value::Ok;
+    }
+    auto& q     = active_queues.at(message_id);
+    auto& users = active_queues.at(message_id).users;
+    std::stringstream ss;
+    for (const auto& i : users)
+    {
+        ss << "<@" << i << "> ";
+    }
+    ss << "\nQueue finished! Please get ready to play " << (q.game_ ? *q.game_ : "a game")
+       << " with " << (q.name_ ? *q.name_ : "friends!") << "!";
+    send_removable_message(bot, ss.str(), reaction.channel);
+    bot.get_context()->del(qb::endpoints::message(reaction.channel, message_id));
+    active_queues.erase(message_id);
+    return qb::Result::Value::Ok;
 }

--- a/src/components/games/gamequeue.hpp
+++ b/src/components/games/gamequeue.hpp
@@ -10,7 +10,7 @@ namespace qb
 class Queue
 {
 public:
-    Queue(std::optional<std::string> name, std::optional<std::string> game, int max_size, int time)
+    Queue(std::optional<std::string> name, std::optional<std::string> game, std::optional<int> max_size, std::optional<std::chrono::duration<long>> time)
         : name_(name), game_(game), max_size_(max_size), time_(time)
     {
     }
@@ -31,9 +31,9 @@ public:
     std::vector<std::string> users;
 
     // maximum number of users allowed in queue
-    int max_size_;
+    std::optional<int>  max_size_;
 
-    int time_;
+    std::optional<std::chrono::duration<long>> time_;
 };
 
 class QueueComponent : public Component

--- a/src/components/games/gamequeue.hpp
+++ b/src/components/games/gamequeue.hpp
@@ -4,6 +4,7 @@
 #include "../component.hpp"
 
 #include <optional>
+#include <chrono>
 
 namespace qb
 {

--- a/src/components/games/gamequeue.hpp
+++ b/src/components/games/gamequeue.hpp
@@ -10,7 +10,10 @@ namespace qb
 class Queue
 {
 public:
-    Queue(std::optional<std::string> name, std::optional<std::string> game, std::optional<int> max_size, std::optional<std::chrono::duration<long>> time)
+    Queue(std::optional<std::string> name,
+          std::optional<std::string> game,
+          std::optional<int> max_size,
+          std::optional<std::chrono::duration<long>> time)
         : name_(name), game_(game), max_size_(max_size), time_(time)
     {
     }
@@ -31,7 +34,7 @@ public:
     std::vector<std::string> users;
 
     // maximum number of users allowed in queue
-    std::optional<int>  max_size_;
+    std::optional<int> max_size_;
 
     std::optional<std::chrono::duration<long>> time_;
 };
@@ -43,6 +46,8 @@ public:
     qb::Result remove_queue(const std::string& cmd, const api::Message& msg, Bot& bot);
     nlohmann::json send_yn_message(Queue& queue, Bot& bot, const std::string& message, const std::string& channel);
     void register_actions(Actions<>& actions) override;
+
+    qb::Result end_queue(const std::string& message_id, const api::Reaction reaction, Bot& bot);
 
 private:
     std::unordered_map<std::string, Queue> active_queues;

--- a/src/components/games/gamequeue.hpp
+++ b/src/components/games/gamequeue.hpp
@@ -3,23 +3,35 @@
 
 #include "../component.hpp"
 
+#include <optional>
+
 namespace qb
 {
-class Queue {
-    public:
-    Queue(std::string name, std::string game, int max_size, int time) 
-        : name_(name), game_(game), max_size_(max_size), time_(time) {}
-    
+class Queue
+{
+public:
+    Queue(std::optional<std::string> name, std::optional<std::string> game, int max_size, int time)
+        : name_(name), game_(game), max_size_(max_size), time_(time)
+    {
+    }
 
     std::string to_str() const;
-    const std::string name_;
-    const std::string game_;
+    std::string get_name() const
+    {
+        return name_ ? *name_ : "anonymous name";
+    }
+    std::string get_game() const
+    {
+        return game_ ? *game_ : "anonymous game";
+    }
+    const std::optional<std::string> name_;
+    const std::optional<std::string> game_;
 
-    //contains user_ids currently in queue
+    // contains user_ids currently in queue
     std::vector<std::string> users;
 
-    //maximum number of users allowed in queue
-    int max_size_; 
+    // maximum number of users allowed in queue
+    int max_size_;
 
     int time_;
 };
@@ -31,15 +43,12 @@ public:
     qb::Result remove_queue(const std::string& cmd, const api::Message& msg, Bot& bot);
     nlohmann::json send_yn_message(Queue& queue, Bot& bot, const std::string& message, const std::string& channel);
     void register_actions(Actions<>& actions) override;
-    
+
 private:
     std::unordered_map<std::string, Queue> active_queues;
 
-    qb::Result add_yn_reaction( const std::string& message_id, const api::Message& message, Bot& bot);
-    
+    qb::Result add_yn_reaction(const std::string& message_id, const api::Message& message, Bot& bot);
 };
 
-
-
-}
+} // namespace qb
 #endif

--- a/src/components/games/gamequeue.hpp
+++ b/src/components/games/gamequeue.hpp
@@ -3,8 +3,11 @@
 
 #include "../component.hpp"
 
-#include <optional>
 #include <chrono>
+#include <memory>
+#include <optional>
+
+#include <boost/asio/steady_timer.hpp>
 
 namespace qb
 {
@@ -38,6 +41,8 @@ public:
     std::optional<int> max_size_;
 
     std::optional<std::chrono::duration<long>> time_;
+
+    std::optional<boost::asio::steady_timer> timer_{};
 };
 
 class QueueComponent : public Component
@@ -45,10 +50,10 @@ class QueueComponent : public Component
 public:
     qb::Result add_queue(const std::string& cmd, const api::Message& msg, Bot& bot);
     qb::Result remove_queue(const std::string& cmd, const api::Message& msg, Bot& bot);
-    nlohmann::json send_yn_message(Queue& queue, Bot& bot, const std::string& message, const std::string& channel);
+    nlohmann::json send_yn_message(Queue&& queue, Bot& bot, const std::string& message, const std::string& channel);
     void register_actions(Actions<>& actions) override;
 
-    qb::Result end_queue(const std::string& message_id, const api::Reaction reaction, Bot& bot);
+    qb::Result end_queue(const std::string& message_id, const api::Reaction& reaction, Bot& bot);
     void dump_debug() const;
 
 private:

--- a/src/components/games/gamequeue.hpp
+++ b/src/components/games/gamequeue.hpp
@@ -48,6 +48,7 @@ public:
     void register_actions(Actions<>& actions) override;
 
     qb::Result end_queue(const std::string& message_id, const api::Reaction reaction, Bot& bot);
+    void dump_debug() const;
 
 private:
     std::unordered_map<std::string, Queue> active_queues;

--- a/src/utils/parse.cpp
+++ b/src/utils/parse.cpp
@@ -1,7 +1,8 @@
 #include "parse.hpp"
+#include <iostream>
 
-#include "components/config.hpp"
 #include "api/emoji.hpp"
+#include "components/config.hpp"
 #include <algorithm>
 #include <cctype>
 
@@ -55,10 +56,117 @@ bool qb::parse::startswithword(const std::string& str, const std::string& start)
            ((start.size() < str.size()) && !isalpha(str[start.size()]) && str.substr(0, start.size()) == start);
 }
 
+qb::parse::SplitNumber qb::parse::split_number(const std::string& s)
+{
+    auto start = std::find_if(s.begin(), s.end(), [](char c) { return c != ' '; });
+    if (start == s.end()) return {};
+    auto num_end = std::find_if(start, s.end(), [](char c) { return !isdigit(c); });
+    if (start == num_end) return SplitNumber{{}, s};
+    return SplitNumber{std::stoi(std::string(start, num_end)), {num_end, s.end()}};
+}
+
+bool qb::parse::is_valid_time_trailer(const std::string& s)
+{
+    // d4h -> d
+    // daysofthemonth5555 -> daysofthemonth
+    // desparate55 -> desparate
+    std::string non_digits{s.begin(),
+                           std::find_if(s.begin(), s.end(), [](char c) { return isdigit(c); })};
+    // very bad but very functional! A for effort
+    if (non_digits.size() > 7 || non_digits.size() == 0) return false;
+    if (::qb::parse::in(non_digits[0], std::string{"hmsd"})) return true;
+    return false;
+}
+
+std::chrono::duration<long> get_seconds(const std::string& trailer, long num)
+{
+    using ld = std::chrono::duration<long>;
+    if (trailer[0] == 's') return ld(num);
+    if (trailer[0] == 'm') return ld(num * 60);
+    if (trailer[0] == 'h') return ld(num * 60 * 60);
+    if (trailer[0] == 'd') return ld(num * 60 * 60 * 24);
+    return ld(0);
+}
+
+void qb::parse::decompose_argument(qb::parse::DecomposedCommand& res, std::string in)
+{
+    try
+    {
+        // Check if we only got a number
+        auto [first_num, first_trail] = split_number(in);
+        if (first_num && first_trail.empty())
+        {
+            res.numeric_arguments.push_back(*first_num);
+            return;
+        }
+        // Check if we only got a string (no leading number)
+        if (!first_num)
+        {
+            res.arguments.push_back(in);
+            return;
+        }
+        // Okay, we got a number with trailing characters.
+        if (!is_valid_time_trailer(first_trail))
+        {
+            res.arguments.push_back(in);
+            return;
+        }
+        // no months+ support yet
+        std::chrono::duration<long> s(0);
+        s += get_seconds(first_trail, *first_num);
+        std::string prev_trail = first_trail; // = d5h or similar
+        while (true)
+        {
+            // so currently prev_trail is something like d123d123d
+            // 5h or similar
+            prev_trail = std::string{std::find_if(prev_trail.begin(), prev_trail.end(), isdigit),
+                                     prev_trail.end()};
+            // now we do the above and have 123d123d
+            // now here we get 123, d123d
+            // if trailer is empty, we return. if not a valid time trailer,
+            // we also return.
+            // eventually we get down to 123d
+            // then our next iteration we don't find any numbers
+            // so we return:
+            if (prev_trail.empty())
+            {
+                res.duration_arguments.push_back(s);
+                return;
+            }
+            auto [num, trail] = split_number(prev_trail);
+            prev_trail        = trail;
+            // Okay, random trailing numbers, nevermind.
+            if (trail.empty() || !is_valid_time_trailer(trail))
+            {
+                res.arguments.push_back(in);
+                return;
+            }
+            s += get_seconds(trail, *num);
+        }
+    }
+    catch (const std::exception& e)
+    {
+        res.arguments.push_back(in);
+        return;
+    }
+}
+
+qb::parse::DecomposedCommand qb::parse::decompose_command(const std::string& command)
+{
+    qb::parse::DecomposedCommand ret;
+    auto cmds = split(command);
+    if (cmds.size() < 2) return ret;
+    for (auto itr = cmds.begin() + 2; itr != cmds.end(); itr++)
+    {
+        decompose_argument(ret, *itr);
+    }
+    return ret;
+}
+
 std::tuple<std::string, std::vector<std::string>> qb::parse::get_time(std::vector<std::string> to_search)
 {
     /**
-     * Looking at this function now (13/02/21) 
+     * Looking at this function now (13/02/21)
      * it seems like this, match(2).1, and match(2).2 are all
      * tools for parsing time expressions out of strings.
      * However, none of them seem particularly useful.
@@ -203,7 +311,8 @@ std::string qb::parse::get_command_name(std::string str)
     return {s, std::find_if(s, str.end(), isspace)};
 }
 
-bool qb::parse::compare_emotes(const std::string& s, const qb::api::Emoji& e) {
+bool qb::parse::compare_emotes(const std::string& s, const qb::api::Emoji& e)
+{
     if (e.id) return compare_emotes(s, *e.id);
     return compare_emotes(s, *e.name);
 }

--- a/src/utils/parse.cpp
+++ b/src/utils/parse.cpp
@@ -156,7 +156,7 @@ qb::parse::DecomposedCommand qb::parse::decompose_command(const std::string& com
     qb::parse::DecomposedCommand ret;
     auto cmds = split(command);
     if (cmds.size() < 2) return ret;
-    for (auto itr = cmds.begin() + 2; itr != cmds.end(); itr++)
+    for (auto itr = cmds.begin() + 1; itr != cmds.end(); itr++)
     {
         decompose_argument(ret, *itr);
     }

--- a/src/utils/parse.hpp
+++ b/src/utils/parse.hpp
@@ -6,6 +6,8 @@
 #include <vector>
 #include <optional>
 #include <algorithm>
+#include <chrono>
+
 namespace qb::api
 {
 struct Emoji;
@@ -42,12 +44,33 @@ inline bool startswith(const std::string& str, const std::string& start)
 /** Returns whether the first input string starts with the second followed by a non-alphanumeric character. **/
 bool startswithword(const std::string& str, const std::string& start);
 
+/**
+ * !qb queue jackbox quickgame 4 10m
+ * vector<std::string> "queue", "jackbox"
+ * vector<int> 4
+ * vector<std::chrono::duration::seconds> 10
+ */
+struct DecomposedCommand {
+    std::vector<std::string> arguments;
+    std::vector<long> numeric_arguments;
+    std::vector<std::chrono::duration<long>> duration_arguments;
+};
+
+struct SplitNumber {
+    std::optional<long> number;
+    std::string trailing;
+};
+bool is_valid_time_trailer(const std::string& s);
+SplitNumber split_number(const std::string& s);
+void decompose_argument(DecomposedCommand& res, std::string in);
+DecomposedCommand decompose_command(const std::string& command);
+
 std::tuple<std::string, std::vector<std::string>> get_time(std::vector<std::string>);
 std::tuple<std::string, std::vector<std::string>> match(std::string, std::vector<std::string>);
 bool match(std::string, std::string);
 
 template <typename Type, typename Range>
-bool in(Type t, Range range)
+bool in(Type t, const Range& range)
 {
     // Currently an inefficient but functional approach.
     for (const auto maybe_t : range)

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -51,7 +51,6 @@ Iter select_randomly(Iter start, Iter end)
     static std::mt19937 gen(rd());
     return select_randomly(start, end, gen);
 }
-
 } // namespace qb
 
 #endif // UTILS_HPP

--- a/test/Test_Parse.cpp
+++ b/test/Test_Parse.cpp
@@ -98,7 +98,8 @@ TEST(Parse, is_valid_time_trailer)
     ASSERT_TRUE(is_valid_time_trailer("d5h"));
 }
 
-TEST(Parse, split_number) {
+TEST(Parse, split_number)
+{
     auto [fn, ft] = split_number("4d5h");
     ASSERT_TRUE(fn);
     ASSERT_FALSE(ft.empty());
@@ -112,7 +113,8 @@ TEST(Parse, split_number) {
     ASSERT_EQ(nt, "h");
 }
 
-TEST(Parse, decompose_argument) {
+TEST(Parse, decompose_argument)
+{
     DecomposedCommand cmd;
     std::string s;
 
@@ -127,26 +129,57 @@ TEST(Parse, decompose_argument) {
     EXPECT_EQ(cmd.duration_arguments.size(), 0);
     ASSERT_EQ(cmd.arguments.size(), 2);
     ASSERT_EQ(cmd.arguments[1], "4d5lifetime-subscriptions-to-walmart!");
-    
+
     s = "4d5h";
     decompose_argument(cmd, s);
     EXPECT_EQ(cmd.numeric_arguments.size(), 0);
     EXPECT_EQ(cmd.duration_arguments.size(), 1);
     ASSERT_EQ(cmd.arguments.size(), 2);
-    ASSERT_EQ(cmd.duration_arguments[0].count(), std::chrono::duration<long>((4*24*60*60) + 5*60*60).count());
+    ASSERT_EQ(cmd.duration_arguments[0].count(),
+              std::chrono::duration<long>((4 * 24 * 60 * 60) + 5 * 60 * 60).count());
 
     s = "4d5h5m2s";
     decompose_argument(cmd, s);
     EXPECT_EQ(cmd.numeric_arguments.size(), 0);
     EXPECT_EQ(cmd.duration_arguments.size(), 2);
     ASSERT_EQ(cmd.arguments.size(), 2);
-    ASSERT_EQ(cmd.duration_arguments[0].count(), std::chrono::duration<long>((4*24*60*60) + 5*60*60).count());
-    ASSERT_EQ(cmd.duration_arguments[1].count(), std::chrono::duration<long>((4*24*60*60) + 5*60*60 + 5*60 + 2).count());
+    ASSERT_EQ(cmd.duration_arguments[0].count(),
+              std::chrono::duration<long>((4 * 24 * 60 * 60) + 5 * 60 * 60).count());
+    ASSERT_EQ(cmd.duration_arguments[1].count(),
+              std::chrono::duration<long>((4 * 24 * 60 * 60) + 5 * 60 * 60 + 5 * 60 + 2).count());
 
     s = "3421";
     decompose_argument(cmd, s);
     EXPECT_EQ(cmd.numeric_arguments.size(), 1);
     EXPECT_EQ(cmd.duration_arguments.size(), 2);
     ASSERT_EQ(cmd.arguments.size(), 2);
+    ASSERT_EQ(cmd.numeric_arguments[0], 3421);
+}
+
+TEST(Parse, decompose_command)
+{
+    auto cmd =
+        decompose_command(std::string{"empty-thing "
+                                      "hello! "
+                                      "4d5lifetime-subscriptions-to-walmart! "
+                                      "4d5h "
+                                      "4d5h5m2s "
+                                      "3421"});
+
+    ASSERT_EQ(cmd.numeric_arguments.size(), 1);
+    ASSERT_EQ(cmd.arguments.size(), 2);
+    ASSERT_EQ(cmd.duration_arguments.size(), 2);
+
+    // Arguments
+    ASSERT_EQ(cmd.arguments[0], "hello!");
+    ASSERT_EQ(cmd.arguments[1], "4d5lifetime-subscriptions-to-walmart!");
+
+    // Duration arguments
+    ASSERT_EQ(cmd.duration_arguments[0].count(),
+              std::chrono::duration<long>((4 * 24 * 60 * 60) + 5 * 60 * 60).count());
+    ASSERT_EQ(cmd.duration_arguments[1].count(),
+              std::chrono::duration<long>((4 * 24 * 60 * 60) + 5 * 60 * 60 + 5 * 60 + 2).count());
+
+    // Numeric arguments
     ASSERT_EQ(cmd.numeric_arguments[0], 3421);
 }

--- a/test/Test_Parse.cpp
+++ b/test/Test_Parse.cpp
@@ -88,3 +88,65 @@ TEST(Parse, get_trailingest_digits)
     ASSERT_EQ(get_trailingest_digits("hellohello"), std::string{""});
     ASSERT_EQ(get_trailingest_digits("he33lo123hello"), std::string{"123"});
 }
+
+TEST(Parse, is_valid_time_trailer)
+{
+    std::string s{"d5h"};
+    std::string nd{s.begin(), std::find_if(s.begin(), s.end(), [](char c) { return isdigit(c); })};
+    ASSERT_EQ(nd, "d");
+    ASSERT_TRUE(::qb::parse::in('d', std::string{"hmsd"}));
+    ASSERT_TRUE(is_valid_time_trailer("d5h"));
+}
+
+TEST(Parse, split_number) {
+    auto [fn, ft] = split_number("4d5h");
+    ASSERT_TRUE(fn);
+    ASSERT_FALSE(ft.empty());
+    ASSERT_EQ(*fn, 4);
+    ASSERT_EQ(ft, "d5h");
+
+    auto [nn, nt] = split_number("5h");
+    ASSERT_TRUE(nn);
+    ASSERT_FALSE(nt.empty());
+    ASSERT_EQ(*nn, 5);
+    ASSERT_EQ(nt, "h");
+}
+
+TEST(Parse, decompose_argument) {
+    DecomposedCommand cmd;
+    std::string s;
+
+    s = "hello!";
+    decompose_argument(cmd, s);
+    ASSERT_EQ(cmd.arguments.size(), 1);
+    ASSERT_EQ(cmd.arguments[0], "hello!");
+
+    s = "4d5lifetime-subscriptions-to-walmart!";
+    decompose_argument(cmd, s);
+    EXPECT_EQ(cmd.numeric_arguments.size(), 0);
+    EXPECT_EQ(cmd.duration_arguments.size(), 0);
+    ASSERT_EQ(cmd.arguments.size(), 2);
+    ASSERT_EQ(cmd.arguments[1], "4d5lifetime-subscriptions-to-walmart!");
+    
+    s = "4d5h";
+    decompose_argument(cmd, s);
+    EXPECT_EQ(cmd.numeric_arguments.size(), 0);
+    EXPECT_EQ(cmd.duration_arguments.size(), 1);
+    ASSERT_EQ(cmd.arguments.size(), 2);
+    ASSERT_EQ(cmd.duration_arguments[0].count(), std::chrono::duration<long>((4*24*60*60) + 5*60*60).count());
+
+    s = "4d5h5m2s";
+    decompose_argument(cmd, s);
+    EXPECT_EQ(cmd.numeric_arguments.size(), 0);
+    EXPECT_EQ(cmd.duration_arguments.size(), 2);
+    ASSERT_EQ(cmd.arguments.size(), 2);
+    ASSERT_EQ(cmd.duration_arguments[0].count(), std::chrono::duration<long>((4*24*60*60) + 5*60*60).count());
+    ASSERT_EQ(cmd.duration_arguments[1].count(), std::chrono::duration<long>((4*24*60*60) + 5*60*60 + 5*60 + 2).count());
+
+    s = "3421";
+    decompose_argument(cmd, s);
+    EXPECT_EQ(cmd.numeric_arguments.size(), 1);
+    EXPECT_EQ(cmd.duration_arguments.size(), 2);
+    ASSERT_EQ(cmd.arguments.size(), 2);
+    ASSERT_EQ(cmd.numeric_arguments[0], 3421);
+}


### PR DESCRIPTION
Adds a parser (see #12) for parsing commands that contain a mixture of numbers, times, and strings. This is a very basic implementation and should probably be rewritten if time allows later down the line.

Adds the ability for the queue command to recognize the delete reaction (`remove_message`) being applied to the Queue message, and finish the queue early. This addresses #15, although it's worth keeping in mind that a way to cancel the queue might need to be added. (This should be relatively simple to do, simply requiring adding a `cancel` reaction & checking for it in the callback)

**TODO** it might be worth addressing #13 as well, as we do now have the time information & can quite easily add the async callback for ending the queue (especially considering the method already exists, we just need to capture everything properly)