### PR TITLE
Support bot commands via STDIN

### DIFF
--- a/src/api/channel.hpp
+++ b/src/api/channel.hpp
@@ -1,0 +1,34 @@
+#ifndef QB_CHANNEL_HPP
+#define QB_CHANNEL_HPP
+
+#include "web/strings.hpp"
+
+namespace qb::api
+{
+struct Channel
+{
+    Channel() = default;
+    Channel(const std::string& id, const std::string& guild) : id(id), guild(guild)
+    {
+    }
+
+    const std::string id;
+    const std::string guild;
+};
+} // namespace qb::api
+
+namespace qb::endpoints
+{
+inline std::string message(const qb::api::Channel& channel, const std::string& message_id)
+{
+    return ::qb::endpoints::message(channel.id, message_id);
+}
+
+inline web::EndpointURI reaction(const qb::api::Channel& channel, const std::string& message_id, const std::string& emoji)
+{
+    return web::EndpointURI{"/api/v8/channels/" + channel.id + "/messages/" + message_id +
+                            "/reactions/" + emoji + "/@me"};
+};
+} // namespace qb::endpoints
+
+#endif // QB_CHANNEL_HPP

--- a/src/bot.cpp
+++ b/src/bot.cpp
@@ -556,14 +556,23 @@ void qb::Bot::handle_io_read(const boost::system::error_code& error, std::size_t
 {
     if (error)
     {
-        qb::log::err("Encountered i/o read error: ", error.message(), " (", error.category().name(),
-                     ':', error.value(), ')');
-        return;
-    }      
+        if (error == boost::asio::error::misc_errors::not_found)
+        {
+            qb::log::err("Too much data input through STDIN. Bytes read: ", bytes_transferred);
+            stdin_io_->cleanse();
+        }
+        else
+        {
+            qb::log::err("Encountered i/o read error: ", error.message(), " (",
+                         error.category().name(), ':', error.value(), ')');
+            return;
+        }
+    }
     const auto cmd = stdin_io_->read(bytes_transferred);
     qb::log::point("Got i/o read: ", cmd);
-    if (cmd == "stop") {
-        shutdown(); 
+    if (cmd == "stop")
+    {
+        shutdown();
         return;
     }
     stdin_io_->async_read();

--- a/src/bot.cpp
+++ b/src/bot.cpp
@@ -711,7 +711,7 @@ void qb::Bot::shutdown()
         qb::log::warn("Error while attempting to disconnect websocket: ", e.what());
     }
     ws_.reset();
-    web_ctx_->shutdown();
+    web_ctx_->shutdown(true);
     qb::log::point("Shutdown completed.");
 }
 

--- a/src/bot.cpp
+++ b/src/bot.cpp
@@ -1,17 +1,17 @@
 #include "bot.hpp"
 
 #include "components/games/gamequeue.hpp"
-#include "components/tools/sprint.hpp"
-#include "components/tools/todo.hpp"
 #include "components/games/hangman.hpp"
 #include "components/messages.hpp"
 #include "components/sentiment.hpp"
+#include "components/tools/sprint.hpp"
+#include "components/tools/todo.hpp"
+#include "utils/async_stdin.hpp"
 #include "utils/debug.hpp"
 #include "utils/fileio.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/parse.hpp" // For command parsing
 #include "utils/utils.hpp" // For get_bot_token
-#include "utils/async_stdin.hpp"
 #include <algorithm>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/beast/core.hpp>
@@ -257,119 +257,6 @@ void qb::Bot::list(const std::string&, const std::string& channel)
     send(qb::messages::keys(qb::parse::concatenate(qb::fileio::skribbl::keys())), channel);
 }
 
-// void qb::Bot::queue(const std::string& cmd, const nlohmann::json& data)
-// {
-//     const std::string channel = data["channel_id"];
-//     const std::string guild   = data["guild_id"];
-//     const std::string msg_id  = data["id"];
-
-//     using namespace qb::parse;
-//     auto contents = split(cmd.substr(6));
-
-//     /*
-//     // Should be in the format of [time] [choices...]
-//     // Order should be irrelevant, assuming time is properly formatted.
-//     auto [time, games] = get_time(contents);
-
-//     if (time == "")
-//     {
-//     //    send(qb::messages::queue_needs_time(), channel);
-//     }*/
-
-//     // Functionality before abstraction
-//     // !qb queue Activity [Max Participants | Timeout]
-
-//     if (contents.size() != 2)
-//     {
-//         send(
-//             "Current format for queue is: queue [Activity] [Time | Max Participants] (e.g. queue
-//             " "Soccer 3m or queue Chess 2)", channel);
-//         return;
-//     }
-
-//     int param = 0;
-//     bool time = false;
-//     try
-//     {
-//         size_t p{0};
-//         param = stoi(contents.at(1), &p);
-
-//         if (p != contents.at(1).size())
-//         {
-//             time = true;
-//         }
-//     }
-//     catch (const std::invalid_argument&)
-//     {
-//         send(
-//             "Current format for queue is: queue [Activity] [Time | Max Participants] (e.g. queue
-//             " "Soccer 3m or queue Chess 2)", channel);
-//         return;
-//     }
-
-// if (time)
-//     qb::log::point("Starting time queue with value of ", param);
-// else
-//     qb::log::point("Starting person queue with value of ", param);
-
-// if (time)
-// {
-//     auto [it, b] = queues_.emplace(std::piecewise_construct, std::make_tuple(msg_id),
-//                                    std::make_tuple(guild, channel, param, web_ctx_->ioc_ptr()));
-//     if (!b)
-//     {
-//         send("Something failed when creating the queue. Please try again!", channel);
-//     }
-//     it->second.async_wait(std::bind(&qb::Bot::handle_queue_timeout, this, msg_id, std::placeholders::_1),
-//                           std::chrono::minutes(param));
-// }
-// else
-// {
-//     auto [it, b] = queues_.emplace(std::piecewise_construct, std::make_tuple(msg_id),
-//                                    std::make_tuple(guild, channel, param));
-//     if (!b)
-//     {
-//         send("Something failed when creating the queue. Please try again!", channel);
-//     }
-// }
-
-// Write our own parsing logic here, for now
-// It can be assumed that data is valid and contains what it must
-//     if (queues_.find(guild) == queues_.end())
-//     {
-//         queues_.emplace(guild, std::vector<nlohmann::json>{});
-//     }
-
-//     // send(messages::queue_start(contents), channel);
-//     send("Queuing for " + contents.at(0) + "! Respond to this message with " +
-//              qb::fileio::get_emote("yes") + " to join the queue, " +
-//              qb::fileio::get_emote("maybe") + " to indicate a 'maybe', or " +
-//              qb::fileio::get_emote("no") + " to indicate a definite no.",
-//          channel);
-
-// }
-
-// void qb::Bot::handle_queue_timeout(const std::string& message_id, const boost::system::error_code& error)
-// {
-//     qb::log::point("Handling queue timeout for message id ", message_id);
-//     if (error)
-//     {
-//         qb::log::err(error.message());
-//         return;
-//     }
-
-//     if (auto it = queues_.find(message_id); it != queues_.end())
-//     {
-//         std::string channel = std::move(it->second.channel_id_);
-//         queues_.erase(it);
-//         send("Queue is complete!", channel);
-//     }
-//     else
-//     {
-//         qb::log::warn("Could not find that message ID in the map.");
-//     }
-// }
-
 void qb::Bot::store(const std::string& cmd, const std::string& channel)
 {
     // This command has variants, so we need to get the actual length of the command
@@ -581,7 +468,8 @@ void qb::Bot::read_handler(const boost::system::error_code& error, std::size_t b
     if (log_loud_) qb::log::point("Parsing received data. Bytes transferred: ", bytes_transferred);
     if (error)
     {
-        qb::log::err("Encountered read error: ", error.message(), " (", error.category().name(), ':', error.value(), ')');
+        qb::log::err("Encountered read error: ", error.message(), " (", error.category().name(),
+                     ':', error.value(), ')');
         return;
     }
     assert(bytes_transferred != 0);
@@ -641,7 +529,7 @@ void qb::Bot::read_handler(const boost::system::error_code& error, std::size_t b
 
 void qb::Bot::attempt_ws_reconnect(bool start_read)
 {
-    const auto socket_info = web_ctx_->get(web::Endpoint::gateway_bot);
+    const auto socket_info       = web_ctx_->get(web::Endpoint::gateway_bot);
     const std::string socket_url = socket_info["url"];
     try
     {
@@ -664,8 +552,21 @@ void qb::Bot::attempt_ws_reconnect(bool start_read)
     ping_sender({});
 }
 
-void qb::Bot::handle_io_read(const boost::system::error_code& error, std::size_t bytes_transferred) {
-    qb::log::point("Got an io read.");
+void qb::Bot::handle_io_read(const boost::system::error_code& error, std::size_t bytes_transferred)
+{
+    if (error)
+    {
+        qb::log::err("Encountered i/o read error: ", error.message(), " (", error.category().name(),
+                     ':', error.value(), ')');
+        return;
+    }      
+    const auto cmd = stdin_io_->read(bytes_transferred);
+    qb::log::point("Got i/o read: ", cmd);
+    if (cmd == "stop") {
+        shutdown(); 
+        return;
+    }
+    stdin_io_->async_read();
 }
 
 void qb::Bot::start()
@@ -681,7 +582,10 @@ void qb::Bot::start()
     timer_.emplace(*web_context.ioc_ptr(), boost::asio::chrono::milliseconds(hb_interval_ms_));
 
     qb::log::point("Potentially launching serverside I/O.");
-    qb::async_stdin_read(*web_context.ioc_ptr(), std::bind(&qb::Bot::handle_io_read, this, std::placeholders::_1, std::placeholders::_2));
+    stdin_io_ = std::make_unique<stdin_io>(
+        *web_context.ioc_ptr(),
+        std::bind(&qb::Bot::handle_io_read, this, std::placeholders::_1, std::placeholders::_2));
+    stdin_io_->async_read();
 
     // Make API call to Discord /gateway/bot/ to get a WebSocket URL
     auto socket_info             = web_context.get(web::Endpoint::gateway_bot);
@@ -733,6 +637,7 @@ void qb::Bot::shutdown()
     if (dead) return;
     dead = true;
     qb::log::point("Beginning shutdown.");
+    if (stdin_io_) stdin_io_->close();
     // Stop the timer.
     timer_->cancel();
     // Close the websocket.
@@ -745,6 +650,7 @@ void qb::Bot::shutdown()
         qb::log::warn("Error while attempting to disconnect websocket: ", e.what());
     }
     ws_.reset();
+    web_ctx_->shutdown();
     qb::log::point("Shutdown completed.");
 }
 

--- a/src/bot.hpp
+++ b/src/bot.hpp
@@ -117,6 +117,8 @@ private:
     std::unique_ptr<stdin_io> stdin_io_{nullptr};
 
     std::optional<std::string> identity_;
+    
+    std::optional<api::Message> bound_msg_{};
 
     unsigned int hb_interval_ms_{0};      // Interval between heartbeats.
     bool outstanding_write_{false};       // True if an async_write is currently in progress.

--- a/src/bot.hpp
+++ b/src/bot.hpp
@@ -1,11 +1,12 @@
 #ifndef BOT_HPP
 #define BOT_HPP
 
+#include "api/channel.hpp"
 #include "api/reaction.hpp"
 #include "components/action.hpp"
 #include "components/queue.hpp"
-#include "web/web.hpp"
 #include "utils/async_stdin.hpp"
+#include "web/web.hpp"
 #include <boost/beast/core/flat_buffer.hpp>
 #include <boost/system/error_code.hpp>
 #include <optional>
@@ -50,6 +51,7 @@ private:
     /** opcode and event handlers **/
     void handle_hello(const nlohmann::json& payload);
     void handle_event(const nlohmann::json& payload);
+    bool handle_command(const std::string& cmd, const qb::api::Message& msg, bool is_explicit = false);
 
     /** PUBLIC API
      * void send(std::string msg, std::string channel)
@@ -75,12 +77,18 @@ public: /** Send is a part of our public API currently. */
     void on_message_reaction(const api::Message& message, BasicAction<api::Reaction> action);
 
     // scary, will be removed one day
-    web::context* get_context() { return web_ctx_; }
+    web::context* get_context()
+    {
+        return web_ctx_;
+    }
 
     bool is_identity(const api::Message& message);
 
     // VERY BAD TODO THIS IS A HACK
-    std::optional<std::string>& idref() { return identity_; }
+    std::optional<std::string>& idref()
+    {
+        return identity_;
+    }
 
 private:
     /** Command handlers. **/
@@ -90,7 +98,7 @@ private:
     void recall(const std::string& cmd, const std::string& channel);
     void list(const std::string& cmd, const std::string& channel);
 
-    void configure(const std::string& cmd, const nlohmann::json& data);
+    void configure(const std::string& cmd, const api::Channel& channel);
     void recall_emote(const std::string& cmd, const std::string& channel);
     void assign_emote(const std::string& cmd, const std::string& channel);
 
@@ -122,10 +130,10 @@ private:
     bool write_outgoing_{false}; // Debug - Fully print outgoing WebSocket data.
     bool log_loud_{false};       // Debug - For lack of a better setup, this prints more.
 
-    // std::unordered_map<std::string, qb::queue> queues_; 
+    // std::unordered_map<std::string, qb::queue> queues_;
 
     // Our actual queues.
-    
+
     // Hashmap of callbacks; these are our commands.
     ::qb::Actions<api::Message> actions_;
 

--- a/src/bot.hpp
+++ b/src/bot.hpp
@@ -5,6 +5,7 @@
 #include "components/action.hpp"
 #include "components/queue.hpp"
 #include "web/web.hpp"
+#include "utils/async_stdin.hpp"
 #include <boost/beast/core/flat_buffer.hpp>
 #include <boost/system/error_code.hpp>
 #include <optional>
@@ -105,6 +106,7 @@ private:
     boost::beast::flat_buffer buffer_;                 // Persistent read buffer
     std::optional<boost::asio::steady_timer> timer_{}; // Persistent write timer
     web::context* web_ctx_{nullptr};                   // Provides HTTP operations
+    std::unique_ptr<stdin_io> stdin_io_{nullptr};
 
     std::optional<std::string> identity_;
 

--- a/src/bot.hpp
+++ b/src/bot.hpp
@@ -35,6 +35,8 @@ private:
     void read_handler(const boost::system::error_code& error, std::size_t bytes_transferred);
     // Called after any async_write completes.
     void write_complete_handler(const boost::system::error_code& error, std::size_t bytes_transferred);
+    // Called if we get IO input
+    void handle_io_read(const boost::system::error_code& error, std::size_t bytes_transferred);
 
     // Helper method: Sends a ping `ms` milliseconds after being called, asynchronously.
     void dispatch_ping_in(unsigned int ms);

--- a/src/components/component.hpp
+++ b/src/components/component.hpp
@@ -33,6 +33,8 @@ protected:
     }
 
     nlohmann::json send_removable_message(Bot& bot, const std::string& message, const std::string& channel);
+
+    nlohmann::json send_removable_message(Bot& bot, const std::string& message, const api::Channel& channel);
     
 
     template<typename Func, typename Class>

--- a/src/components/games/gamequeue.cpp
+++ b/src/components/games/gamequeue.cpp
@@ -73,7 +73,7 @@ qb::Result qb::QueueComponent::add_queue(const std::string& cmd, const api::Mess
 
     auto endpoint = msg.endpoint();
     bot.get_context()->del(endpoint);
-    send_yn_message(std::move(new_queue), bot, new_queue.to_str(), channel);
+    send_yn_message(std::move(new_queue), bot, new_queue.to_str(), channel.id);
     return qb::Result::ok();
 }
 

--- a/src/components/games/hangman.cpp
+++ b/src/components/games/hangman.cpp
@@ -29,7 +29,7 @@ qb::Result qb::Hangman::guess_hangman(const std::string& cmd, const api::Message
     const auto guess = qb::parse::trim(std::string(std::find(cmd.begin(), cmd.end(), ' '), cmd.end()));
     if (guess_word(guess))
     {
-        bot.send(msg.user.username.value_or("That") + " is correct! The word is " + word_ + "! Game ending...", channel);
+        bot.send(msg.user.username.value_or("That") + " is correct! The word is " + word_ + "! Game ending...", channel.id);
         reset();
         return qb::Result::ok();
     }

--- a/src/components/tools/sprint.cpp
+++ b/src/components/tools/sprint.cpp
@@ -60,7 +60,7 @@ qb::Result qb::SprintComponent::add_sprint(const std::string& cmd, const api::Me
 
     auto endpoint = msg.endpoint();
     bot.get_context()->del(endpoint);
-    send_yn_message(std::move(new_sprint), bot, new_sprint.to_str(), channel);
+    send_yn_message(std::move(new_sprint), bot, new_sprint.to_str(), channel.id);
     return qb::Result::ok();
 }
 

--- a/src/utils/async_stdin.hpp
+++ b/src/utils/async_stdin.hpp
@@ -2,33 +2,75 @@
 #define ASYNC_STDIN_HPP
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#pragma message "Compiling with STDIN support ENABLED."
+
+#include "debug.hpp"
+
+#include <boost/asio.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <boost/beast/core/flat_buffer.hpp>
-#include <boost/asio.hpp>
 #include <optional>
 #include <stdio.h>
-static std::optional<boost::asio::posix::stream_descriptor> io_stream;
-static boost::beast::flat_buffer io_buffer;
+
 namespace qb
 {
-template <typename ioc_t, typename F>
-void async_stdin_read(ioc_t& ioc, F&& handler)
+struct stdin_io
 {
-    using namespace boost::asio;
-    if (!io_stream)
+    template <typename F>
+    stdin_io(boost::asio::io_context& ioc, F&& handler)
+        : io_stream(ioc, ::dup(STDIN_FILENO) /* Duplicates the stream */), io_handler(handler)
     {
-        io_stream = posix::stream_descriptor(ioc, STDIN_FILENO);
+        qb::log::point("Created stdin i/o.");
     }
-    async_read(*io_stream, io_buffer, handler);
-}
+
+    std::string read(std::size_t bytes) {
+        // maybe replace with this later
+        // https://stackoverflow.com/questions/877652/copy-a-streambufs-contents-to-a-string
+        std::string out; 
+        out.resize(bytes - 1);
+        io_buffer.sgetn(out.data(), bytes - 1);
+        io_buffer.consume(1);
+        return out;
+    }
+
+    void async_read()
+    {
+        qb::log::point("Launching stdin i/o.");
+        boost::asio::async_read_until(io_stream, io_buffer, '\n', io_handler);
+    }
+
+    void close()
+    {
+        qb::log::point("Shutting down stdin i/o.");
+        io_stream.close();
+    }
+
+    boost::asio::posix::stream_descriptor io_stream;
+    boost::asio::streambuf io_buffer{32};
+    std::function<void(const boost::system::error_code& error, std::size_t bytes_transferred)> io_handler;
+};
 } // namespace qb
 #else
-template <typename ioc_t, typename F>
-void async_stdin_read(ioc_t& ioc, F&& handler)
+#pragma message "Compiling with STDIN support DISABLED."
+namespace qb
 {
-    return;
-}
+struct stdin_io
+{
+    template <typename F>
+    stdin_io(boost::asio::io_context&, F&&)
+    {
+    }
+
+    void async_read()
+    {
+    }
+
+    void close()
+    {
+    }
+};
+} // namespace qb
 #endif
 
 #endif // ASYNC_STDIN_HPP

--- a/src/utils/async_stdin.hpp
+++ b/src/utils/async_stdin.hpp
@@ -1,0 +1,34 @@
+#ifndef ASYNC_STDIN_HPP
+#define ASYNC_STDIN_HPP
+
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/posix/stream_descriptor.hpp>
+#include <boost/beast/core/flat_buffer.hpp>
+#include <boost/asio.hpp>
+#include <optional>
+#include <stdio.h>
+static std::optional<boost::asio::posix::stream_descriptor> io_stream;
+static boost::beast::flat_buffer io_buffer;
+namespace qb
+{
+template <typename ioc_t, typename F>
+void async_stdin_read(ioc_t& ioc, F&& handler)
+{
+    using namespace boost::asio;
+    if (!io_stream)
+    {
+        io_stream = posix::stream_descriptor(ioc, STDIN_FILENO);
+    }
+    async_read(*io_stream, io_buffer, handler);
+}
+} // namespace qb
+#else
+template <typename ioc_t, typename F>
+void async_stdin_read(ioc_t& ioc, F&& handler)
+{
+    return;
+}
+#endif
+
+#endif // ASYNC_STDIN_HPP

--- a/src/utils/parse.hpp
+++ b/src/utils/parse.hpp
@@ -29,6 +29,10 @@ std::string rtrim(std::string str, const std::string& to_trim = " ");
 /** Splits a string by the character delimiter. **/
 std::vector<std::string> split(const std::string&, char delim = ' ');
 
+inline std::string get_until(const std::string& s, char delim) {
+    return std::string{s.begin(), std::find(s.begin(), s.end(), delim)};
+}
+
 /** Takes a string and returns if it is a stop command. **/
 inline bool is_stop(std::string msg)
 {

--- a/src/web/strings.hpp
+++ b/src/web/strings.hpp
@@ -36,14 +36,16 @@ const std::string bot       = "/api/v6/gateway/bot";
 const auto channel_msg      = [](const std::string& channel_id) {
     return "/api/v6/channels/" + channel_id + "/messages";
 };
-const auto message      = [](const std::string& channel_id, const std::string& message_id) {
+inline std::string message(const std::string& channel_id, const std::string& message_id)
+{
     return "/api/v8/channels/" + channel_id + "/messages/" + message_id;
 };
 const auto interaction = [](const std::string& specifier) {
     return "/api/v8/interactions" + specifier;
 };
 
-const auto reaction = [](const std::string& channel_id, const std::string& message_id, const std::string& emoji) {
+inline web::EndpointURI reaction(const std::string& channel_id, const std::string& message_id, const std::string& emoji)
+{
     return web::EndpointURI{"/api/v8/channels/" + channel_id + "/messages/" + message_id +
                             "/reactions/" + emoji + "/@me"};
 };

--- a/src/web/web.cpp
+++ b/src/web/web.cpp
@@ -52,10 +52,10 @@ void web::context::initialize()
 
 web::context::~context()
 {
-    if (initialized_) shutdown();
+    if (initialized_) shutdown(true);
 }
 
-void web::context::shutdown()
+void web::context::shutdown(bool soft)
 {
     initialized_ = false;
     // Properly close the stream to make sure the remote server is aware.
@@ -67,7 +67,7 @@ void web::context::shutdown()
         ec = {};
     }
 
-    if (!ioc_.stopped()) ioc_.stop();
+    if (!soft && !ioc_.stopped()) ioc_.stop();
 
     if (ec)
     {

--- a/src/web/web.cpp
+++ b/src/web/web.cpp
@@ -63,9 +63,12 @@ void web::context::shutdown()
     stream_.shutdown(ec);
     if (ec == asio::error::eof || ec == asio::ssl::error::stream_truncated || ec == asio::error::broken_pipe)
     {
-        qb::log::warn("Ignoring error: ", beast::system_error{ec}.what());
+        qb::log::warn("Ignoring error during web context shutdown: ", beast::system_error{ec}.what());
         ec = {};
     }
+
+    if (!ioc_.stopped()) ioc_.stop();
+
     if (ec)
     {
         qb::log::err("Encountered error while shutting down web context stream.");

--- a/src/web/web.hpp
+++ b/src/web/web.hpp
@@ -40,7 +40,7 @@ public:
 
     ~context();
     // Shuts down the web context (mainly the HTTP stream).
-    void shutdown();
+    void shutdown(bool soft = true);
 
     // Returns a wrapped WebSocket connection to the url passed as a parameter.
     [[nodiscard]] WSWrapper acquire_websocket(const std::string& url);


### PR DESCRIPTION
This pull request:

- Fleshes out some of the API wrappers (adds `api::Channel`, adds simpler creation of `api::Message`) 
- Removes old `queue` code
- Refactors the command code flow to allow for commands to be read from multiple locations, not just in `MESSAGE_CREATE` events
- Fixes some bugs with `shutdown` to allow for more graceful bot disconnects (using `!.. stop`)
- Introduces STDIN as an option for sending commands directly to the bot
- Supports binding to a channel for STDIN
- Supports reading commands automatically and executing them on startup via a data file